### PR TITLE
Fix homepage typos

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -4,7 +4,7 @@
   <div class="container">
   <div id="loyalty-offer-container"></div>
     <h1>Adobe Target Remote Offers Demo</h1>
-    <p class="lead">Personalized loyatly epxiernces using cachhed remote offers and adience targeting</p>
+    <p class="lead">Personalized loyalty experiences using cached remote offers and audience targeting</p>
 
     <div style="background: linear-gradient(135deg, #3b82f6, #2563eb); color: white; padding: 25px; border-radius: 12px; margin: 25px auto; max-width: 700px; box-shadow: 0 4px 20px rgba(37, 99, 235, 0.3);">
       <h3 style="margin-top: 0; font-size: 1.3em; display: flex; align-items: center; gap: 10px;">


### PR DESCRIPTION
Fixed spelling errors in lead paragraph on the homepage:
- loyatly → loyalty
- epxiernces → experiences  
- cachhed → cached
- adience → audience

Fixes #7